### PR TITLE
Recognize back-ported generic versions

### DIFF
--- a/kernel-clean
+++ b/kernel-clean
@@ -15,8 +15,8 @@ ALLEXTRA=`dpkg -l "linux-image-extra-*" | grep -E '^..[[:space:]]+linux-image-ex
 NEWEST=`echo "$ALLIMAGES" | tail -n1`
 echo "Newest installed kernel: $NEWEST"
 
-# Print version of newest installed generic kernel
-GENERIC=`dpkg -l linux-image-generic | grep -E '^ii' | awk '{print $3}' `
+# Print version of newest installed generic kernel (including Ubuntu's HWE versions)
+GENERIC=`dpkg -l 'linux-image-generic*' | grep -E '^ii' | awk '{print $3}' | sort -V | tail -1`
 if [ -n "$GENERIC" ]; then
 	echo "Newest installed generic kernel version: $GENERIC"
 fi


### PR DESCRIPTION
Hi Stephan,
I think you may wanna pull this. I have been testing it for 3 years and had no issues with it so presume it is safe. :)
This fixes an issue with generic images that do not exactly match `linux-image-generic`, e.g., `linux-image-generic-hwe-16.04`.
BTW is there still no viable alternative to this stupid script? :)